### PR TITLE
Fix Excel table-collapse bug and add auto-load on scrolling to top

### DIFF
--- a/sites.config.json
+++ b/sites.config.json
@@ -10,7 +10,7 @@
         ],
         "selectors": {
             "messageTurn": "section[data-testid^=\"conversation-turn-\"]",
-            "scrollContainer": "main"
+            "scrollContainer": "div[data-scroll-root]"
         },
         "messageIdAttribute": "data-turn-id",
         "statusAnchors": {
@@ -55,7 +55,8 @@
         ],
         "selectors": {
             "messageTurn": "[data-test-render-count]",
-            "scrollContainer": ".overflow-y-scroll"
+            "scrollContainer": "div[data-autoscroll-container]",
+            "scrollContainerAlt": ".overflow-y-scroll"
         },
         "statusAnchors": {
             "name": "[data-testid=\"chat-title-button\"]",
@@ -95,7 +96,8 @@
         ],
         "selectors": {
             "messageTurn": "user-query, model-response",
-            "scrollContainer": "infinite-scroller.chat-history"
+            "scrollContainer": "infinite-scroller[data-test-id=\"chat-history-container\"]",
+            "scrollContainerAlt": "infinite-scroller.chat-history"
         },
         "statusAnchors": {
             "name": "bard-logo",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -57,6 +57,13 @@ onMessage(async (message): Promise<unknown> => {
             return updated;
         }
 
+        case MessageType.TOGGLE_AUTO_LOAD: {
+            const current = await loadConfig();
+            const updated = await saveConfig({ autoLoad: !current.autoLoad });
+            await broadcastToContentScripts({ type: MessageType.CONFIG_UPDATED, payload: updated });
+            return updated;
+        }
+
         default:
             return undefined;
     }

--- a/src/content/DOMObserver.ts
+++ b/src/content/DOMObserver.ts
@@ -9,6 +9,7 @@ export interface DOMObserverCallbacks {
     onMessagesReset(): void;
     getLastTrackedMessageId(): string | null;
     hasTrackedMessageId(id: string): boolean;
+    onScrollToTop(): void;
 }
 
 export class DOMObserver {
@@ -20,12 +21,17 @@ export class DOMObserver {
     private readonly callbacks: DOMObserverCallbacks;
     private lastUrl = "";
     private urlPollTimer: ReturnType<typeof setInterval> | null = null;
+    private totalMessages = 0;
+    private visibleMessages = 0;
+    private scrollEl: HTMLElement | null = null;
+    private scrollRaf: number | null = null;
+    private autoLoadEnabled = false;
 
     constructor(currentSite: SiteConfig, callbacks: DOMObserverCallbacks) {
         this.currentSite = currentSite;
         this.selectors = currentSite.selectors;
         this.callbacks = callbacks;
-    }
+        this.scrollEl = this.findScrollContainer();    }
 
     start(): void {
         if (this.observer) {
@@ -67,6 +73,51 @@ export class DOMObserver {
 
     queryAllMessages(): HTMLElement[] {
         return Array.from(document.querySelectorAll<HTMLElement>(this.selectors.messageTurn));
+    }
+
+    // Updates internal message counts based on the provided numbers.
+    // Required for gating the scroll listener callback.
+    updateMessageStats(total: number, visible: number): void {
+        this.totalMessages = total;
+        this.visibleMessages = visible;
+    }
+
+    SetAutoLoad(enable: boolean): void {    
+        if(this.autoLoadEnabled === enable) return; // No change in state, do nothing
+        this.autoLoadEnabled = enable;
+
+        if(this.autoLoadEnabled){
+            logger.debug("Auto-load enabled: will load one more message when user scrolls to top");
+            
+            // Attach scroll listener to the resolved scroll container so callers
+            // can react to user scrolling (auto-load, etc.)
+            if (!this.scrollEl) this.scrollEl = this.findScrollContainer();
+            while(!this.scrollEl) {
+                setTimeout(() => {
+                    this.scrollEl = this.findScrollContainer();
+
+                }, 1000); // Keep trying to find a scroll container every second, as some sites load it asynchronously (e.g. Claude)
+                if(this.scrollEl) 
+                    break;    
+            }
+            this.handleScroll(); // Check scroll position immediately in case user is already near top when enabling auto-load
+            if (this.scrollEl) this.scrollEl.addEventListener("scroll", this.handleScroll, { passive: true });
+        }else{
+            logger.debug("Auto-load disabled: will not load more messages on scroll");
+
+            // Detach scroll listener to disable auto-load functionality
+            if (this.scrollEl) this.scrollEl.removeEventListener("scroll", this.handleScroll);
+            if (this.scrollRaf) cancelAnimationFrame(this.scrollRaf);
+            this.scrollRaf = null;
+        }
+    }
+
+    resetAutoLoad(): void {
+        if(this.autoLoadEnabled){
+            logger.debug("Resetting auto-load state: temporarily disabling and re-enabling to reset internal state");
+            this.SetAutoLoad(false);
+            this.SetAutoLoad(true);
+        }
     }
 
     findScrollContainer(): HTMLElement | null {
@@ -155,12 +206,46 @@ export class DOMObserver {
         }
 
         if (removedMessages.length > 0) {
-            logger.debug(`${removedMessages.length} message turn(s) removed`);
+            logger.debug(`${removedMessages.length} message turn(s) removed out of ${this.totalMessages} total tracked messages`);
             this.callbacks.onMessagesRemoved(removedMessages);
+            if(removedMessages.length >= this.totalMessages) {
+                // If all or nearly all messages are removed at once,
+                //  it's likely a conversation reset scenario like the chatgpt + excel scenario,
+                //  the existing message tracking can get out of sync, so we trigger a full reset to be safe
+                // This fixes the issue where the "entire chat disappears," but there's a bug in chatgpt's ui 
+                // which disables the prompt area, after collapsing the excel table, until a page refresh.
+                logger.debug(`Detected ${removedMessages.length} removed messages, triggering full reset`);
+                this.callbacks.onMessagesReset();
+                this.scrollEl?.scrollTo({ top: this.scrollEl?.scrollHeight ?? 0, behavior: "smooth" }); // Scroll to bottom after reset
+            }
         }
     }
 
     private isMessageTurn(el: HTMLElement): boolean {
         return el.matches?.(this.selectors.messageTurn) ?? false;
     }
+
+    private readonly handleScroll = (): void => {
+        if (this.scrollRaf) cancelAnimationFrame(this.scrollRaf);
+        if(this.visibleMessages === this.totalMessages) return; // No hidden messages, no need to check scroll position
+        this.scrollRaf = requestAnimationFrame(() => {
+            const el = this.scrollEl ?? this.findScrollContainer();
+            if (!el) return;
+            var percentFromTop = getPercentFromTop(el);
+            if (this.callbacks.onScrollToTop && percentFromTop <= 10) this.callbacks.onScrollToTop();
+            percentFromTop = getPercentFromTop(el);
+            // console.log("Percent from top:", percentFromTop);
+            // If user is still near the top after loading more messages, scroll down slightly to prevent multiple triggers
+            if(percentFromTop <= 10){
+                el?.scrollTo({ top: 0.1 * (this.scrollEl?.scrollHeight ?? 0), behavior: "smooth" });
+                logger.debug("Auto scrolled down slightly to prevent multiple auto-load triggers");
+            }
+        });
+
+        function getPercentFromTop(el: HTMLElement): number {
+            const max = el.scrollHeight - el.clientHeight;
+            const top = el.scrollTop;
+            return max > 0 ? (top / max) * 100 : 100;
+        }
+    };
 }

--- a/src/content/MessageManager.ts
+++ b/src/content/MessageManager.ts
@@ -69,10 +69,11 @@ export class MessageManager {
         });
     }
 
-    loadMore(): number {
+    loadMore(toLoad?: number): number { // Added optional parameter to specify how many messages to load
         if (!this.config.enabled) return 0;
+        if(this.messages.length === this.visibleCount) return 0; // No hidden messages to load
         const hidden = this.messages.filter((m) => !m.visible);
-        const toReveal = hidden.slice(-this.config.loadMoreBatchSize * 2);
+        const toReveal = hidden.slice(( toLoad ? -toLoad : -this.config.loadMoreBatchSize) * 2);
         for (const msg of toReveal) this.showMessage(msg);
         this.cachedVisibleCount = this.visibleCount; // Preserve currently visible messages when user sends new prompt
         logger.debug(`revealed ${toReveal.length} additional messages`);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -54,24 +54,15 @@ async function bootstrap(): Promise<void> {
         getLastTrackedMessageId: () => messageManager.getLastTrackedMessageId(),
         hasTrackedMessageId: (id: string) =>
             messageManager.hasTrackedMessageId(id),
+        onScrollToTop: loadOneMoreMessage,
     });
 
     domObserver.start();
+    domObserver.SetAutoLoad(config.autoLoad);
     scheduleInitialScan();
     onConfigChanged(handleConfigUpdated);
     onMessage(handleExtensionMessage);
 
-    // Diagnostic: log selector match info to help debug site configs
-    setTimeout(() => {
-        const msgs = domObserver.queryAllMessages();
-        const scrollEl = domObserver.findScrollContainer();
-        console.log(
-            `[AI Chat Speed Booster] Site: ${currentSite.name} | ` +
-            `Selector: "${currentSite.selectors.messageTurn}" → ${msgs.length} match(es) | ` +
-            `Scroll container: ${scrollEl ? "found" : "NOT found"} | ` +
-            `Is Dynamic: ${currentSite.isDynamic ? "Yes" : "No"}`,
-        );
-    }, 3000);
 }
 
 /**
@@ -84,6 +75,17 @@ function scheduleInitialScan(): void {
             messageManager.initialise(existing);
             refreshUI();
             logger.info(`initial scan: ${existing.length} messages`);
+            // Moved the log here so it runs after actually finding messages.
+            setTimeout(() => {
+                const msgs = domObserver.queryAllMessages();
+                const scrollEl = domObserver.findScrollContainer();
+                console.log(
+                    `[AI Chat Speed Booster] Site: ${currentSite.name} | ` +
+                    `Selector: "${currentSite.selectors.messageTurn}" → ${msgs.length} match(es) | ` +
+                    `Scroll container: ${scrollEl ? "found" : "NOT found"} | ` +
+                    `Is Dynamic: ${currentSite.isDynamic ? "Yes" : "No"}`,
+                );
+            }, 100);
             // After hiding old messages, scroll the container to the bottom so
             // the user always sees the most recent turn.  Only needed for sites
             // that don't support CSS scroll anchoring (e.g. Gemini's custom
@@ -191,6 +193,7 @@ function handleMessagesReset(): void {
     loadMoreButton.hide();
     const messages = domObserver.queryAllMessages();
     messageManager.initialise(messages);
+    domObserver.resetAutoLoad(); // Reset auto-load state to prevent it from getting stuck after a reset
     refreshUI();
     // Do NOT scroll here — the user is actively reading a streaming response.
     // Any forced scroll would jump away from the content they are watching.
@@ -215,6 +218,15 @@ function handleLoadMore(): void {
         // Nothing left to reveal from DOM — check if fetch interceptor trimmed
         refreshUI();
     }
+}
+
+/**
+ * Reveals one additional conversation turn, used for auto-loading when the user scrolls to the top.
+ */
+function loadOneMoreMessage(): void {
+    if(!config.autoLoad) return; // Don't auto-load if the user has disabled the feature
+    messageManager.loadMore(1);
+    refreshUI();
 }
 
 /**
@@ -247,7 +259,7 @@ function refreshUI(): void {
             document.documentElement.removeAttribute("data-acsb-trimmed");
         }
 
-        if (status.hiddenMessages > 0 && config.enabled) {
+        if (status.hiddenMessages > 1 && config.enabled) { // changed to 1 since conversations that were aborted will result in 1 turn being added, i.e., the user prompt.
             // Normal Load More mode — there are still hidden DOM elements
             const firstVisible = findFirstVisibleMessage();
             const container = findMessageContainer();
@@ -267,6 +279,9 @@ function refreshUI(): void {
         } else {
             loadMoreButton.hide();
         }
+
+        domObserver.updateMessageStats(Math.floor(status.totalMessages / 2), Math.floor(status.visibleMessages / 2)); // Divide by 2 to convert from turns to conversations
+        domObserver.SetAutoLoad(config.autoLoad); // Update auto-load state in DOM observer based on latest config
 
         if (!config.enabled || !config.showStatus || status.totalMessages === 0) {
             statusIndicator.hide();

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -97,6 +97,16 @@
             </div>
             <div class="setting">
                 <div class="setting__info">
+                    <span class="setting__label">Auto Load</span>
+                    <span class="setting__hint">Automatically load more on scrolling</span>
+                </div>
+                <label class="toggle" aria-label="Enable or disable auto-load">
+                    <input type="checkbox" id="toggle-auto-load" class="toggle__input">
+                    <span class="toggle__slider"></span>
+                </label>
+            </div>
+            <div class="setting">
+                <div class="setting__info">
                     <span class="setting__label">Status indicator</span>
                     <span class="setting__hint">Floating badge position</span>
                 </div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -14,6 +14,7 @@ const positionButtons = positionPicker.querySelectorAll<HTMLButtonElement>(".pos
 const lightIcon = document.querySelector(".theme-toggle__icon.lucide-sun") as HTMLElement;
 const darkIcon = document.querySelector(".theme-toggle__icon.lucide-moon") as HTMLElement;
 const themeToggle = document.getElementById("theme-toggle") as HTMLButtonElement;
+const toggleAutoLoad = document.getElementById("toggle-auto-load") as HTMLInputElement; // New auto-load toggle element
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -50,6 +51,7 @@ async function init(): Promise<void> {
 function renderConfig(config: ExtensionConfig): void {
     toggleEnabled.checked = config.enabled;
     toggleStatus.checked = config.showStatus;
+    toggleAutoLoad.checked = config.autoLoad;
     toggleFetchIntercept.checked = config.fetchInterceptEnabled;
     visibleLimitInput.value = String(config.visibleMessageLimit);
     batchSizeInput.value = String(config.loadMoreBatchSize);
@@ -118,6 +120,12 @@ toggleEnabled.addEventListener("change", async () => {
 
 toggleStatus.addEventListener("change", async () => {
     const config = await safeSendMessage<ExtensionConfig>({ type: MessageType.TOGGLE_STATUS });
+    if (config) renderConfig(config);
+    await refreshStatus();
+});
+
+toggleAutoLoad.addEventListener("change", async () => {
+    const config = await safeSendMessage<ExtensionConfig>({ type: MessageType.TOGGLE_AUTO_LOAD });
     if (config) renderConfig(config);
     await refreshStatus();
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_CONFIG: Readonly<ExtensionConfig> = Object.freeze({
     statusPosition: "top-right",
     fetchInterceptEnabled: true,
     theme: "dark",
+    autoLoad: true,
 });
 
 /** localStorage key used by settings bridge → MAIN-world fetch interceptor. */

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -26,6 +26,7 @@ function sanitiseConfig(raw: Partial<ExtensionConfig> | undefined): ExtensionCon
             ? base.statusPosition
             : DEFAULT_CONFIG.statusPosition,
         fetchInterceptEnabled: typeof base.fetchInterceptEnabled === "boolean" ? base.fetchInterceptEnabled : DEFAULT_CONFIG.fetchInterceptEnabled,
+        autoLoad: typeof base.autoLoad === "boolean" ? base.autoLoad : DEFAULT_CONFIG.autoLoad, // New addition for auto-load validation
         theme: base.theme === "light" || base.theme === "dark" ? base.theme : DEFAULT_CONFIG.theme, // New addition for theme validation
     };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -16,6 +16,8 @@ export interface ExtensionConfig {
     readonly fetchInterceptEnabled: boolean;
     // UI theme preference.
     readonly theme: Theme;
+    // Auto loads 1 extra conversation turn when the user scrolls to the top of the chat.
+    readonly autoLoad: boolean; // New addition for auto-load preference
 }
 
 export interface TrackedMessage {
@@ -33,6 +35,7 @@ export enum MessageType {
     TOGGLE_ENABLED = "TOGGLE_ENABLED",
     TOGGLE_STATUS = "TOGGLE_STATUS",
     TOGGLE_FETCH_INTERCEPT = "TOGGLE_FETCH_INTERCEPT",
+    TOGGLE_AUTO_LOAD = "TOGGLE_AUTO_LOAD", // New message type for toggling auto-load
 }
 
 export interface ExtensionMessage {


### PR DESCRIPTION
## Summary
This PR includes two user-facing improvements:

1. Adds a new Auto Load feature (#17) that automatically reveals one additional conversation turn when the user scrolls near the top.
2. Fixes the Excel collapse edge case (#18), where collapsing an expanded table can temporarily remove all messages from the DOM and cause the chat to disappear.


## What Changed
- Added `Auto Load` toggle to popup UI and wired it to extension config/storage.
- Added `TOGGLE_AUTO_LOAD` message handling.
- Added DOM scroll-based auto-load trigger via `DOMObserver` callback (`onScrollToTop`).
- Added guarded auto-load logic in content script (`loadOneMoreMessage`) to reveal one turn at a time.
- Added reset safeguard for mass removals:
  - When `removedMessages.length >= totalMessages`, trigger full reset/re-initialization.
  - This addresses the Excel collapse scenario where all messages are temporarily removed after collapsing the table.
- Changed scroll container selectors for ChatGPT, Claude, and Gemini since the previous ones were not working reliably.

## Tested

> Tested on Chrome - ChatGPT, Claude, Gemini

#### Auto-load toggle behavior
- Disabled in popup → auto-load does not trigger on top scroll.
- Enabled in popup → auto-load triggers and reveals one more turn near top.
- Enabled & scrollbar at top → auto-load triggers immediately to reveal one more turn, then scrolls down by 10% to prevent immediate retriggering.
- Re-toggling enable/disable works as expected.

#### Excel edge case
- Verified the mass-removal path where all messages were removed.
- Confirmed `onMessagesReset()` restores the conversation correctly in this case.

#### Conversation window
- Confirmed this does not break window-like message rendering.
- When a new prompt is sent, both hidden and total message counts are incremented to preserve the window.

## Notes
- Auto-load is intentionally incremental (one additional turn per trigger) to avoid over-expansion and preserve reading context.
- Existing load-more/full-load behavior remains intact.
- ChatGPT currently has a separate UI bug where collapsing the Excel table can disable the prompt input until refresh.

Closes #17  
Closes #18