### PR TITLE
feat: weekly request counter for ChatGPT

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/edge/manifest.json
+++ b/browsers/edge/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/safari/manifest.json
+++ b/browsers/safari/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ai-chat-speed-booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ai-chat-speed-booster",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "license": "MIT",
             "devDependencies": {
                 "@playwright/test": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-chat-speed-booster",
-    "version": "1.4.1",
+    "version": "1.4.3",
     "description": "Browser extension that speeds up AI chat apps (ChatGPT, Claude, etc.) by lazily loading conversation messages with FIFO management",
     "private": true,
     "scripts": {

--- a/sites.config.json
+++ b/sites.config.json
@@ -13,7 +13,6 @@
             "scrollContainer": "div[data-scroll-root]",
             "userMessageSelector": "[data-message-author-role=\"user\"]"
         },
-        "weeklyRequestLimit": 3000,
         "messageIdAttribute": "data-turn-id",
         "statusAnchors": {
             "name": "[data-testid=\"model-switcher-dropdown-button\"] > div",

--- a/sites.config.json
+++ b/sites.config.json
@@ -10,8 +10,10 @@
         ],
         "selectors": {
             "messageTurn": "section[data-testid^=\"conversation-turn-\"]",
-            "scrollContainer": "div[data-scroll-root]"
+            "scrollContainer": "div[data-scroll-root]",
+            "userMessageSelector": "[data-message-author-role=\"user\"]"
         },
+        "weeklyRequestLimit": 3000,
         "messageIdAttribute": "data-turn-id",
         "statusAnchors": {
             "name": "[data-testid=\"model-switcher-dropdown-button\"] > div",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,4 +1,4 @@
-import { loadConfig, saveConfig } from "../shared/storage";
+import { loadConfig, saveConfig, loadRequestCount, incrementRequestCount, resetRequestCount } from "../shared/storage";
 import { onMessage, api } from "../shared/browser-api";
 import { MessageType } from "../shared/types";
 import type { ExtensionConfig, ExtensionMessageUnion, ExtensionStatus } from "../shared/types";
@@ -62,6 +62,21 @@ onMessage(async (message): Promise<unknown> => {
             const updated = await saveConfig({ autoLoad: !current.autoLoad });
             await broadcastToContentScripts({ type: MessageType.CONFIG_UPDATED, payload: updated });
             return updated;
+        }
+
+        case MessageType.GET_REQUEST_COUNT: {
+            const siteId = (msg as { payload?: { siteId?: string } }).payload?.siteId ?? "";
+            return await loadRequestCount(siteId);
+        }
+
+        case MessageType.INCREMENT_REQUEST_COUNT: {
+            const incPayload = (msg as { payload?: { siteId?: string; count?: number } }).payload ?? {};
+            return await incrementRequestCount(incPayload.siteId ?? "", incPayload.count ?? 1);
+        }
+
+        case MessageType.RESET_REQUEST_COUNT: {
+            const siteId = (msg as { payload?: { siteId?: string } }).payload?.siteId ?? "";
+            return await resetRequestCount(siteId);
         }
 
         default:

--- a/src/content/DOMObserver.ts
+++ b/src/content/DOMObserver.ts
@@ -26,6 +26,7 @@ export class DOMObserver {
     private scrollEl: HTMLElement | null = null;
     private scrollRaf: number | null = null;
     private autoLoadEnabled = false;
+    private scrollRetryTimer: ReturnType<typeof setInterval> | null = null;
 
     constructor(currentSite: SiteConfig, callbacks: DOMObserverCallbacks) {
         this.currentSite = currentSite;
@@ -82,34 +83,44 @@ export class DOMObserver {
         this.visibleMessages = visible;
     }
 
-    SetAutoLoad(enable: boolean): void {    
-        if(this.autoLoadEnabled === enable) return; // No change in state, do nothing
+    SetAutoLoad(enable: boolean): void {
+        if (this.autoLoadEnabled === enable) return;
         this.autoLoadEnabled = enable;
 
-        if(this.autoLoadEnabled){
+        if (this.autoLoadEnabled) {
             logger.debug("Auto-load enabled: will load one more message when user scrolls to top");
-            
-            // Attach scroll listener to the resolved scroll container so callers
-            // can react to user scrolling (auto-load, etc.)
-            if (!this.scrollEl) this.scrollEl = this.findScrollContainer();
-            while(!this.scrollEl) {
-                setTimeout(() => {
-                    this.scrollEl = this.findScrollContainer();
-
-                }, 1000); // Keep trying to find a scroll container every second, as some sites load it asynchronously (e.g. Claude)
-                if(this.scrollEl) 
-                    break;    
-            }
-            this.handleScroll(); // Check scroll position immediately in case user is already near top when enabling auto-load
-            if (this.scrollEl) this.scrollEl.addEventListener("scroll", this.handleScroll, { passive: true });
-        }else{
+            this.attachScrollListener();
+        } else {
             logger.debug("Auto-load disabled: will not load more messages on scroll");
-
-            // Detach scroll listener to disable auto-load functionality
+            if (this.scrollRetryTimer) {
+                clearInterval(this.scrollRetryTimer);
+                this.scrollRetryTimer = null;
+            }
             if (this.scrollEl) this.scrollEl.removeEventListener("scroll", this.handleScroll);
             if (this.scrollRaf) cancelAnimationFrame(this.scrollRaf);
             this.scrollRaf = null;
         }
+    }
+
+    private attachScrollListener(): void {
+        if (!this.scrollEl) this.scrollEl = this.findScrollContainer();
+        if (this.scrollEl) {
+            this.handleScroll();
+            this.scrollEl.addEventListener("scroll", this.handleScroll, { passive: true });
+            return;
+        }
+        // Scroll container not yet in the DOM (some sites load it asynchronously) — poll until found
+        this.scrollRetryTimer = setInterval(() => {
+            this.scrollEl = this.findScrollContainer();
+            if (this.scrollEl) {
+                clearInterval(this.scrollRetryTimer!);
+                this.scrollRetryTimer = null;
+                if (this.autoLoadEnabled) {
+                    this.handleScroll();
+                    this.scrollEl.addEventListener("scroll", this.handleScroll, { passive: true });
+                }
+            }
+        }, 500);
     }
 
     resetAutoLoad(): void {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,7 +3,7 @@ import { MessageManager } from "./MessageManager";
 import { LoadMoreButton, StatusIndicator } from "./UIComponents";
 import { detectCurrentSite, type SiteConfig } from "../shared/sites";
 import { loadConfig, onConfigChanged } from "../shared/storage";
-import { onMessage } from "../shared/browser-api";
+import { onMessage, sendMessage } from "../shared/browser-api";
 import {
     MessageType,
     type ExtensionConfig,
@@ -115,6 +115,21 @@ function scheduleInitialScan(): void {
 function handleMessagesAdded(elements: HTMLElement[]): void {
     messageManager.addMessages(elements);
     refreshUI();
+    countNewUserRequests(elements);
+}
+
+function countNewUserRequests(elements: HTMLElement[]): void {
+    const sel = currentSite.selectors.userMessageSelector;
+    if (!sel) return;
+    const count = elements.filter(
+        (el) => el.matches(sel) || el.querySelector(sel) !== null,
+    ).length;
+    if (count > 0) {
+        sendMessage({
+            type: MessageType.INCREMENT_REQUEST_COUNT,
+            payload: { siteId: currentSite.id, count },
+        }).catch(() => {});
+    }
 }
 
 /**
@@ -201,7 +216,9 @@ function handleMessagesReset(): void {
 
 function handleExtensionMessage(message: unknown): ExtensionStatus | undefined {
     const msg = message as { type?: string };
-    if (msg.type === MessageType.GET_STATUS) return messageManager.getStatus();
+    if (msg.type === MessageType.GET_STATUS) {
+        return { ...messageManager.getStatus(), siteId: currentSite.id };
+    }
     return undefined;
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -153,6 +153,10 @@ body {
     background: var(--bg-secondary);
 }
 
+.setting[data-tooltip] {
+    cursor: default;
+}
+
 /* Tooltip — fixed so it can't be clipped by any parent overflow */
 .tooltip {
     position: fixed;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -272,3 +272,44 @@ body {
     align-items: center;
     gap: 10px;
 }
+
+.request-counter__right {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.request-count-display {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.request-count-display--warn {
+    color: #e5a000;
+}
+
+.icon-btn {
+    all: unset;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: color var(--transition), background var(--transition);
+}
+
+.icon-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
+}
+
+.icon-btn:focus-visible {
+    outline: 2px solid var(--border-focus);
+    outline-offset: 2px;
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -138,7 +138,7 @@ body {
 }
 
 .popup-settings {
-    padding: 4px 20px 16px;
+    padding: 4px 15px 15px;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -151,6 +151,35 @@ body {
     padding: 8px 12px;
     border-radius: var(--radius-sm);
     background: var(--bg-secondary);
+    position: relative;
+}
+
+/* Tooltip */
+.setting[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-size: 11px;
+    line-height: 1.4;
+    padding: 6px 9px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    width: 200px;
+    white-space: normal;
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.setting[data-tooltip]:hover::after {
+    opacity: 1;
 }
 
 .setting__info {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -273,6 +273,18 @@ body {
     gap: 10px;
 }
 
+/* Paired settings row */
+.setting-row {
+    display: flex;
+    gap: 8px;
+}
+
+.setting-row .setting {
+    flex: 1;
+    min-width: 0;
+}
+
+/* Weekly request counter */
 .request-counter__right {
     display: flex;
     align-items: center;
@@ -280,15 +292,24 @@ body {
     flex-shrink: 0;
 }
 
-.request-count-display {
+.request-count-value {
     font-size: 12px;
     font-variant-numeric: tabular-nums;
     color: var(--text-secondary);
     white-space: nowrap;
 }
 
-.request-count-display--warn {
+.request-count-value--warn {
     color: #e5a000;
+}
+
+.request-limit-sep {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.request-limit-input {
+    width: 52px;
 }
 
 .icon-btn {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -151,34 +151,29 @@ body {
     padding: 8px 12px;
     border-radius: var(--radius-sm);
     background: var(--bg-secondary);
-    position: relative;
 }
 
-/* Tooltip */
-.setting[data-tooltip]::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
+/* Tooltip — fixed so it can't be clipped by any parent overflow */
+.tooltip {
+    position: fixed;
+    width: 220px;
     background: var(--bg-tertiary);
     color: var(--text-primary);
     font-size: 11px;
-    line-height: 1.4;
-    padding: 6px 9px;
+    line-height: 1.5;
+    padding: 7px 10px;
     border-radius: 6px;
     border: 1px solid var(--border);
-    width: 200px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    z-index: 100;
     white-space: normal;
     text-align: left;
-    pointer-events: none;
     opacity: 0;
-    transition: opacity 0.15s ease;
-    z-index: 10;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    transition: opacity 0.12s ease;
 }
 
-.setting[data-tooltip]:hover::after {
+.tooltip.visible {
     opacity: 1;
 }
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,6 +10,7 @@
 
 <body>
     <div class="popup">
+        <div id="tooltip" class="tooltip" role="tooltip"></div>
         <header class="popup-header">
             <div class="popup-header__title-row">
                 <div class="popup-header__brand">
@@ -43,14 +44,14 @@
 
             <!-- Fast mode + Auto load -->
             <div class="setting-row">
-                <div class="setting" data-tooltip="Trims API responses before the page renders them — much faster than hiding messages after the fact. Disable if you notice missing messages.">
+                <div class="setting" data-tooltip="Trims API responses before rendering. Faster than hiding after the fact. Disable if messages appear missing.">
                     <span class="setting__label">Fast mode</span>
                     <label class="toggle" aria-label="Enable or disable fetch interception">
                         <input type="checkbox" id="toggle-fetch-intercept" class="toggle__input">
                         <span class="toggle__slider"></span>
                     </label>
                 </div>
-                <div class="setting" data-tooltip="Automatically reveals one older message when you scroll near the top — so you can keep reading without clicking Load More.">
+                <div class="setting" data-tooltip="Reveals one older message when you scroll to the top, so you can read back without clicking Load More.">
                     <span class="setting__label">Auto load</span>
                     <label class="toggle" aria-label="Enable or disable auto-load">
                         <input type="checkbox" id="toggle-auto-load" class="toggle__input">
@@ -61,14 +62,14 @@
 
             <!-- Visible messages + Batch size -->
             <div class="setting-row">
-                <div class="setting" data-tooltip="How many conversation turns are shown at once. Lower values keep the page fast in very long chats. Hidden turns are still accessible via Load More.">
+                <div class="setting" data-tooltip="Turns shown at once. Lower = faster in long chats. Hidden turns are accessible via Load More.">
                     <div class="setting__info">
                         <span class="setting__label" id="visible-limit-label">Visible</span>
                         <span class="setting__hint">Shown at once</span>
                     </div>
                     <input type="number" id="visible-limit" class="setting__input" min="1" max="200" step="1" aria-labelledby="visible-limit-label">
                 </div>
-                <div class="setting" data-tooltip="How many turns are revealed each time you click Load More. Larger values let you scroll back further in one click.">
+                <div class="setting" data-tooltip="Turns revealed per Load More click. Larger = scroll further back in one click.">
                     <div class="setting__info">
                         <span class="setting__label" id="batch-size-label">Batch</span>
                         <span class="setting__hint">Per load more</span>
@@ -78,7 +79,7 @@
             </div>
 
             <!-- Status indicator -->
-            <div class="setting" data-tooltip="Shows a small floating badge on the chat page with how many messages are hidden and how many are visible. Choose which corner it appears in.">
+            <div class="setting" data-tooltip="Floating badge on the chat page showing hidden vs. visible turns. Pick which corner.">
                 <div class="setting__info">
                     <span class="setting__label">Status indicator</span>
                     <span class="setting__hint">Floating badge position</span>
@@ -98,7 +99,7 @@
             </div>
 
             <!-- Weekly requests (only on sites with userMessageSelector) -->
-            <div class="setting" id="request-counter" hidden data-tooltip="Counts messages you send this week. Set the limit to match your plan (e.g. 3,000 for ChatGPT Plus). Set to 0 to just count with no limit shown.">
+            <div class="setting" id="request-counter" hidden data-tooltip="Counts messages sent this week. Set limit to your plan's cap (e.g. 3,000 for Plus). 0 = count only, no limit.">
                 <div class="setting__info">
                     <span class="setting__label">Weekly requests</span>
                     <span class="setting__hint" id="request-counter-hint">Resets every Monday</span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -105,6 +105,21 @@
                     <span class="toggle__slider"></span>
                 </label>
             </div>
+            <div class="setting" id="request-counter" hidden>
+                <div class="setting__info">
+                    <span class="setting__label">Weekly requests</span>
+                    <span class="setting__hint" id="request-counter-hint">Resets every Monday</span>
+                </div>
+                <div class="request-counter__right">
+                    <span id="request-count-display" class="request-count-display">0</span>
+                    <button id="request-count-reset" class="icon-btn" title="Reset counter" aria-label="Reset weekly request counter">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                            <path d="M3 3v5h5"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
             <div class="setting">
                 <div class="setting__info">
                     <span class="setting__label">Status indicator</span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -19,46 +19,17 @@
                     </svg>
                     <span>Speed Booster</span>
                     <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle theme" aria-pressed="false">
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            class="theme-toggle__icon lucide lucide-sun"
-                        >
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="theme-toggle__icon lucide lucide-sun">
                             <circle cx="12" cy="12" r="4" />
-                            <path d="M12 2v2" />
-                            <path d="M12 20v2" />
-                            <path d="m4.93 4.93 1.41 1.41" />
-                            <path d="m17.66 17.66 1.41 1.41" />
-                            <path d="M2 12h2" />
-                            <path d="M20 12h2" />
-                            <path d="m6.34 17.66-1.41 1.41" />
-                            <path d="m19.07 4.93-1.41 1.41" />
+                            <path d="M12 2v2" /><path d="M12 20v2" />
+                            <path d="m4.93 4.93 1.41 1.41" /><path d="m17.66 17.66 1.41 1.41" />
+                            <path d="M2 12h2" /><path d="M20 12h2" />
+                            <path d="m6.34 17.66-1.41 1.41" /><path d="m19.07 4.93-1.41 1.41" />
                         </svg>
-
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            class="theme-toggle__icon lucide lucide-moon"
-                        >
-                            <path
-                                d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"
-                            />
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="theme-toggle__icon lucide lucide-moon">
+                            <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
                         </svg>
-                    </button>  
+                    </button>
                 </div>
                 <label class="toggle" aria-label="Enable or disable extension">
                     <input type="checkbox" id="toggle-enabled" class="toggle__input">
@@ -69,57 +40,44 @@
         </header>
 
         <section class="popup-settings" aria-label="Settings">
-            <div class="setting">
-                <div class="setting__info">
+
+            <!-- Fast mode + Auto load -->
+            <div class="setting-row">
+                <div class="setting">
                     <span class="setting__label">Fast mode</span>
-                    <span class="setting__hint">Trim API responses before render</span>
+                    <label class="toggle" aria-label="Enable or disable fetch interception">
+                        <input type="checkbox" id="toggle-fetch-intercept" class="toggle__input">
+                        <span class="toggle__slider"></span>
+                    </label>
                 </div>
-                <label class="toggle" aria-label="Enable or disable fetch interception">
-                    <input type="checkbox" id="toggle-fetch-intercept" class="toggle__input">
-                    <span class="toggle__slider"></span>
-                </label>
-            </div>
-            <div class="setting">
-                <div class="setting__info">
-                    <span class="setting__label" id="visible-limit-label">Visible messages</span>
-                    <span class="setting__hint">Conversations shown at once</span>
-                </div>
-                <input type="number" id="visible-limit" class="setting__input" min="1" max="200" step="1"
-                    aria-labelledby="visible-limit-label">
-            </div>
-            <div class="setting">
-                <div class="setting__info">
-                    <span class="setting__label" id="batch-size-label">Batch size</span>
-                    <span class="setting__hint">Revealed per "Load More"</span>
-                </div>
-                <input type="number" id="batch-size" class="setting__input" min="1" max="50" step="1"
-                    aria-labelledby="batch-size-label">
-            </div>
-            <div class="setting">
-                <div class="setting__info">
-                    <span class="setting__label">Auto Load</span>
-                    <span class="setting__hint">Automatically load more on scrolling</span>
-                </div>
-                <label class="toggle" aria-label="Enable or disable auto-load">
-                    <input type="checkbox" id="toggle-auto-load" class="toggle__input">
-                    <span class="toggle__slider"></span>
-                </label>
-            </div>
-            <div class="setting" id="request-counter" hidden>
-                <div class="setting__info">
-                    <span class="setting__label">Weekly requests</span>
-                    <span class="setting__hint" id="request-counter-hint">Resets every Monday</span>
-                </div>
-                <div class="request-counter__right">
-                    <span id="request-count-display" class="request-count-display">0</span>
-                    <button id="request-count-reset" class="icon-btn" title="Reset counter" aria-label="Reset weekly request counter">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                            <path d="M3 3v5h5"/>
-                        </svg>
-                    </button>
+                <div class="setting">
+                    <span class="setting__label">Auto load</span>
+                    <label class="toggle" aria-label="Enable or disable auto-load">
+                        <input type="checkbox" id="toggle-auto-load" class="toggle__input">
+                        <span class="toggle__slider"></span>
+                    </label>
                 </div>
             </div>
+
+            <!-- Visible messages + Batch size -->
+            <div class="setting-row">
+                <div class="setting">
+                    <div class="setting__info">
+                        <span class="setting__label" id="visible-limit-label">Visible</span>
+                        <span class="setting__hint">Shown at once</span>
+                    </div>
+                    <input type="number" id="visible-limit" class="setting__input" min="1" max="200" step="1" aria-labelledby="visible-limit-label">
+                </div>
+                <div class="setting">
+                    <div class="setting__info">
+                        <span class="setting__label" id="batch-size-label">Batch</span>
+                        <span class="setting__hint">Per load more</span>
+                    </div>
+                    <input type="number" id="batch-size" class="setting__input" min="1" max="50" step="1" aria-labelledby="batch-size-label">
+                </div>
+            </div>
+
+            <!-- Status indicator -->
             <div class="setting">
                 <div class="setting__info">
                     <span class="setting__label">Status indicator</span>
@@ -138,6 +96,26 @@
                     </label>
                 </div>
             </div>
+
+            <!-- Weekly requests (only on sites with userMessageSelector) -->
+            <div class="setting" id="request-counter" hidden>
+                <div class="setting__info">
+                    <span class="setting__label">Weekly requests</span>
+                    <span class="setting__hint" id="request-counter-hint">Resets every Monday</span>
+                </div>
+                <div class="request-counter__right">
+                    <span id="request-count-value" class="request-count-value">0</span>
+                    <span id="request-limit-sep" class="request-limit-sep"> / </span>
+                    <input type="number" id="request-limit-input" class="setting__input request-limit-input" min="0" max="99999" step="100" title="Weekly limit (0 = just count)">
+                    <button id="request-count-reset" class="icon-btn" title="Reset counter" aria-label="Reset weekly request counter">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                            <path d="M3 3v5h5"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
         </section>
     </div>
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -43,14 +43,14 @@
 
             <!-- Fast mode + Auto load -->
             <div class="setting-row">
-                <div class="setting">
+                <div class="setting" data-tooltip="Trims API responses before the page renders them — much faster than hiding messages after the fact. Disable if you notice missing messages.">
                     <span class="setting__label">Fast mode</span>
                     <label class="toggle" aria-label="Enable or disable fetch interception">
                         <input type="checkbox" id="toggle-fetch-intercept" class="toggle__input">
                         <span class="toggle__slider"></span>
                     </label>
                 </div>
-                <div class="setting">
+                <div class="setting" data-tooltip="Automatically reveals one older message when you scroll near the top — so you can keep reading without clicking Load More.">
                     <span class="setting__label">Auto load</span>
                     <label class="toggle" aria-label="Enable or disable auto-load">
                         <input type="checkbox" id="toggle-auto-load" class="toggle__input">
@@ -61,14 +61,14 @@
 
             <!-- Visible messages + Batch size -->
             <div class="setting-row">
-                <div class="setting">
+                <div class="setting" data-tooltip="How many conversation turns are shown at once. Lower values keep the page fast in very long chats. Hidden turns are still accessible via Load More.">
                     <div class="setting__info">
                         <span class="setting__label" id="visible-limit-label">Visible</span>
                         <span class="setting__hint">Shown at once</span>
                     </div>
                     <input type="number" id="visible-limit" class="setting__input" min="1" max="200" step="1" aria-labelledby="visible-limit-label">
                 </div>
-                <div class="setting">
+                <div class="setting" data-tooltip="How many turns are revealed each time you click Load More. Larger values let you scroll back further in one click.">
                     <div class="setting__info">
                         <span class="setting__label" id="batch-size-label">Batch</span>
                         <span class="setting__hint">Per load more</span>
@@ -78,7 +78,7 @@
             </div>
 
             <!-- Status indicator -->
-            <div class="setting">
+            <div class="setting" data-tooltip="Shows a small floating badge on the chat page with how many messages are hidden and how many are visible. Choose which corner it appears in.">
                 <div class="setting__info">
                     <span class="setting__label">Status indicator</span>
                     <span class="setting__hint">Floating badge position</span>
@@ -98,7 +98,7 @@
             </div>
 
             <!-- Weekly requests (only on sites with userMessageSelector) -->
-            <div class="setting" id="request-counter" hidden>
+            <div class="setting" id="request-counter" hidden data-tooltip="Counts messages you send this week. Set the limit to match your plan (e.g. 3,000 for ChatGPT Plus). Set to 0 to just count with no limit shown.">
                 <div class="setting__info">
                     <span class="setting__label">Weekly requests</span>
                     <span class="setting__hint" id="request-counter-hint">Resets every Monday</span>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -6,6 +6,7 @@ import { SITES } from "../shared/sites";
 const toggleEnabled = document.getElementById("toggle-enabled") as HTMLInputElement;
 const toggleStatus = document.getElementById("toggle-status") as HTMLInputElement;
 const toggleFetchIntercept = document.getElementById("toggle-fetch-intercept") as HTMLInputElement;
+const toggleAutoLoad = document.getElementById("toggle-auto-load") as HTMLInputElement;
 const visibleLimitInput = document.getElementById("visible-limit") as HTMLInputElement;
 const batchSizeInput = document.getElementById("batch-size") as HTMLInputElement;
 const statusText = document.getElementById("status-text") as HTMLElement;
@@ -15,17 +16,19 @@ const positionButtons = positionPicker.querySelectorAll<HTMLButtonElement>(".pos
 const lightIcon = document.querySelector(".theme-toggle__icon.lucide-sun") as HTMLElement;
 const darkIcon = document.querySelector(".theme-toggle__icon.lucide-moon") as HTMLElement;
 const themeToggle = document.getElementById("theme-toggle") as HTMLButtonElement;
-const toggleAutoLoad = document.getElementById("toggle-auto-load") as HTMLInputElement;
 const requestCounter = document.getElementById("request-counter") as HTMLElement;
-const requestCountDisplay = document.getElementById("request-count-display") as HTMLElement;
+const requestCountValue = document.getElementById("request-count-value") as HTMLElement;
+const requestLimitSep = document.getElementById("request-limit-sep") as HTMLElement;
+const requestLimitInput = document.getElementById("request-limit-input") as HTMLInputElement;
 const requestCountHint = document.getElementById("request-counter-hint") as HTMLElement;
 const requestCountReset = document.getElementById("request-count-reset") as HTMLButtonElement;
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let limitSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let currentSiteId: string | undefined;
-let currentSiteLimit: number | undefined;
+let lastCount = 0;
+let lastWeekStart = 0;
 
-/** Apply the selected theme to the popup UI. */
 function applyTheme(theme: Theme): void {
     document.documentElement.setAttribute("data-theme", theme);
     themeToggle.setAttribute("aria-pressed", String(theme === "light"));
@@ -38,7 +41,6 @@ function applyTheme(theme: Theme): void {
     }
 }
 
-/** Attempt to send a message to the background script; return null on failure. */
 async function safeSendMessage<T>(message: unknown): Promise<T | null> {
     try {
         return (await sendMessage<T>(message)) ?? null;
@@ -49,7 +51,7 @@ async function safeSendMessage<T>(message: unknown): Promise<T | null> {
 
 async function init(): Promise<void> {
     const config = await safeSendMessage<ExtensionConfig>({ type: MessageType.GET_CONFIG });
-    const finalConfig = config ?? DEFAULT_CONFIG; // Fallback to defaults if background script is unreachable
+    const finalConfig = config ?? DEFAULT_CONFIG;
     applyTheme(finalConfig.theme);
     renderConfig(finalConfig);
     await refreshStatus();
@@ -62,9 +64,9 @@ function renderConfig(config: ExtensionConfig): void {
     toggleFetchIntercept.checked = config.fetchInterceptEnabled;
     visibleLimitInput.value = String(config.visibleMessageLimit);
     batchSizeInput.value = String(config.loadMoreBatchSize);
+    requestLimitInput.value = String(config.weeklyRequestLimit);
     settingsSection.setAttribute("aria-disabled", String(!config.enabled));
 
-    // Highlight active position button
     positionButtons.forEach((btn) => {
         btn.classList.toggle("active", btn.dataset.pos === config.statusPosition);
     });
@@ -94,8 +96,7 @@ async function refreshStatus(): Promise<void> {
 async function refreshRequestCounter(): Promise<void> {
     if (!currentSiteId) { requestCounter.hidden = true; return; }
     const site = SITES.find((s) => s.id === currentSiteId);
-    if (!site?.weeklyRequestLimit) { requestCounter.hidden = true; return; }
-    currentSiteLimit = site.weeklyRequestLimit;
+    if (!site?.selectors.userMessageSelector) { requestCounter.hidden = true; return; }
 
     const data = await safeSendMessage<WeeklyRequestCount>({
         type: MessageType.GET_REQUEST_COUNT,
@@ -103,21 +104,23 @@ async function refreshRequestCounter(): Promise<void> {
     });
     if (!data) { requestCounter.hidden = true; return; }
 
+    lastCount = data.count;
+    lastWeekStart = data.weekStart;
     renderRequestCount(data.count, data.weekStart);
     requestCounter.hidden = false;
 }
 
 function renderRequestCount(count: number, weekStart: number): void {
-    const limit = currentSiteLimit ?? 0;
-    requestCountDisplay.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+    const limit = parseInt(requestLimitInput.value, 10);
+    const hasLimit = !isNaN(limit) && limit > 0;
 
-    // Show next reset date (7 days after weekStart)
+    requestCountValue.textContent = count.toLocaleString();
+    requestLimitSep.hidden = !hasLimit;
+    requestCountValue.classList.toggle("request-count-value--warn", hasLimit && count / limit >= 0.8);
+
     const resetDate = new Date(weekStart + 7 * 24 * 60 * 60 * 1000);
     const formatted = resetDate.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
     requestCountHint.textContent = `Resets ${formatted}`;
-
-    // Warn at ≥80 %
-    requestCountDisplay.classList.toggle("request-count-display--warn", limit > 0 && count / limit >= 0.8);
 }
 
 function clampInput(input: HTMLInputElement, min: number, max: number): number {
@@ -128,27 +131,32 @@ function clampInput(input: HTMLInputElement, min: number, max: number): number {
     return value;
 }
 
-/** Debounced auto-save for numeric inputs */
 function scheduleAutoSave(): void {
     if (saveTimer) clearTimeout(saveTimer);
     saveTimer = setTimeout(async () => {
         saveTimer = null;
-        const visibleLimit = clampInput(
-            visibleLimitInput,
-            CONFIG_LIMITS.visibleMessageLimit.min,
-            CONFIG_LIMITS.visibleMessageLimit.max,
-        );
-        const batchSize = clampInput(
-            batchSizeInput,
-            CONFIG_LIMITS.loadMoreBatchSize.min,
-            CONFIG_LIMITS.loadMoreBatchSize.max,
-        );
+        const visibleLimit = clampInput(visibleLimitInput, CONFIG_LIMITS.visibleMessageLimit.min, CONFIG_LIMITS.visibleMessageLimit.max);
+        const batchSize = clampInput(batchSizeInput, CONFIG_LIMITS.loadMoreBatchSize.min, CONFIG_LIMITS.loadMoreBatchSize.max);
         const config = await safeSendMessage<ExtensionConfig>({
             type: MessageType.SET_CONFIG,
             payload: { visibleMessageLimit: visibleLimit, loadMoreBatchSize: batchSize },
         });
         if (config) renderConfig(config);
         await refreshStatus();
+    }, 600);
+}
+
+function scheduleLimitSave(): void {
+    if (limitSaveTimer) clearTimeout(limitSaveTimer);
+    limitSaveTimer = setTimeout(async () => {
+        limitSaveTimer = null;
+        const limit = clampInput(requestLimitInput, CONFIG_LIMITS.weeklyRequestLimit.min, CONFIG_LIMITS.weeklyRequestLimit.max);
+        const config = await safeSendMessage<ExtensionConfig>({
+            type: MessageType.SET_CONFIG,
+            payload: { weeklyRequestLimit: limit },
+        });
+        if (config) renderConfig(config);
+        renderRequestCount(lastCount, lastWeekStart);
     }, 600);
 }
 
@@ -178,6 +186,7 @@ toggleFetchIntercept.addEventListener("change", async () => {
 
 visibleLimitInput.addEventListener("input", scheduleAutoSave);
 batchSizeInput.addEventListener("input", scheduleAutoSave);
+requestLimitInput.addEventListener("input", scheduleLimitSave);
 
 positionPicker.addEventListener("click", async (e) => {
     const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".position-picker__btn");
@@ -190,8 +199,6 @@ positionPicker.addEventListener("click", async (e) => {
     await refreshStatus();
 });
 
-
-/** Theme toggle button listener */
 themeToggle.addEventListener("click", async () => {
     const currentTheme = document.documentElement.getAttribute("data-theme") as "light" | "dark" || "dark";
     const newTheme = currentTheme === "dark" ? "light" : "dark";
@@ -211,7 +218,11 @@ requestCountReset.addEventListener("click", async () => {
         type: MessageType.RESET_REQUEST_COUNT,
         payload: { siteId: currentSiteId },
     });
-    if (data) renderRequestCount(data.count, data.weekStart);
+    if (data) {
+        lastCount = data.count;
+        lastWeekStart = data.weekStart;
+        renderRequestCount(data.count, data.weekStart);
+    }
 });
 
 init();

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,6 +1,7 @@
 import { sendMessage } from "../shared/browser-api";
 import { CONFIG_LIMITS, DEFAULT_CONFIG } from "../shared/constants";
-import { MessageType, Theme, type ExtensionConfig, type ExtensionStatus, type StatusPosition } from "../shared/types";
+import { MessageType, Theme, type ExtensionConfig, type ExtensionStatus, type StatusPosition, type WeeklyRequestCount } from "../shared/types";
+import { SITES } from "../shared/sites";
 
 const toggleEnabled = document.getElementById("toggle-enabled") as HTMLInputElement;
 const toggleStatus = document.getElementById("toggle-status") as HTMLInputElement;
@@ -14,9 +15,15 @@ const positionButtons = positionPicker.querySelectorAll<HTMLButtonElement>(".pos
 const lightIcon = document.querySelector(".theme-toggle__icon.lucide-sun") as HTMLElement;
 const darkIcon = document.querySelector(".theme-toggle__icon.lucide-moon") as HTMLElement;
 const themeToggle = document.getElementById("theme-toggle") as HTMLButtonElement;
-const toggleAutoLoad = document.getElementById("toggle-auto-load") as HTMLInputElement; // New auto-load toggle element
+const toggleAutoLoad = document.getElementById("toggle-auto-load") as HTMLInputElement;
+const requestCounter = document.getElementById("request-counter") as HTMLElement;
+const requestCountDisplay = document.getElementById("request-count-display") as HTMLElement;
+const requestCountHint = document.getElementById("request-counter-hint") as HTMLElement;
+const requestCountReset = document.getElementById("request-count-reset") as HTMLButtonElement;
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let currentSiteId: string | undefined;
+let currentSiteLimit: number | undefined;
 
 /** Apply the selected theme to the popup UI. */
 function applyTheme(theme: Theme): void {
@@ -70,14 +77,47 @@ async function refreshStatus(): Promise<void> {
             statusText.textContent =
                 `${Math.floor(status.visibleMessages / 2)}/${Math.floor(status.totalMessages / 2)} messages visible` +
                 (status.hiddenMessages > 0 ? ` · ${Math.floor(status.hiddenMessages / 2)} hidden` : "");
-            settingsSection.style.display = ""; // Show if the site is a valid site
+            settingsSection.style.display = "";
+            currentSiteId = status.siteId;
+            await refreshRequestCounter();
         } else {
-            settingsSection.style.display = "none"; // Hide if the site is not a valid site
+            settingsSection.style.display = "none";
             statusText.textContent = "Open a supported AI chat to see status";
+            currentSiteId = undefined;
+            requestCounter.hidden = true;
         }
     } catch {
         statusText.textContent = "Unable to fetch status";
     }
+}
+
+async function refreshRequestCounter(): Promise<void> {
+    if (!currentSiteId) { requestCounter.hidden = true; return; }
+    const site = SITES.find((s) => s.id === currentSiteId);
+    if (!site?.weeklyRequestLimit) { requestCounter.hidden = true; return; }
+    currentSiteLimit = site.weeklyRequestLimit;
+
+    const data = await safeSendMessage<WeeklyRequestCount>({
+        type: MessageType.GET_REQUEST_COUNT,
+        payload: { siteId: currentSiteId },
+    });
+    if (!data) { requestCounter.hidden = true; return; }
+
+    renderRequestCount(data.count, data.weekStart);
+    requestCounter.hidden = false;
+}
+
+function renderRequestCount(count: number, weekStart: number): void {
+    const limit = currentSiteLimit ?? 0;
+    requestCountDisplay.textContent = `${count.toLocaleString()} / ${limit.toLocaleString()}`;
+
+    // Show next reset date (7 days after weekStart)
+    const resetDate = new Date(weekStart + 7 * 24 * 60 * 60 * 1000);
+    const formatted = resetDate.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+    requestCountHint.textContent = `Resets ${formatted}`;
+
+    // Warn at ≥80 %
+    requestCountDisplay.classList.toggle("request-count-display--warn", limit > 0 && count / limit >= 0.8);
 }
 
 function clampInput(input: HTMLInputElement, min: number, max: number): number {
@@ -163,6 +203,15 @@ themeToggle.addEventListener("click", async () => {
         applyTheme(config.theme);
         renderConfig(config);
     }
+});
+
+requestCountReset.addEventListener("click", async () => {
+    if (!currentSiteId) return;
+    const data = await safeSendMessage<WeeklyRequestCount>({
+        type: MessageType.RESET_REQUEST_COUNT,
+        payload: { siteId: currentSiteId },
+    });
+    if (data) renderRequestCount(data.count, data.weekStart);
 });
 
 init();

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -212,6 +212,32 @@ themeToggle.addEventListener("click", async () => {
     }
 });
 
+// Tooltip: fixed-position bubble that can't be clipped by popup overflow
+const tooltip = document.getElementById("tooltip") as HTMLElement;
+const TOOLTIP_W = 220; // must match CSS width
+const POPUP_W = 300;   // body width
+
+document.querySelectorAll<HTMLElement>("[data-tooltip]").forEach((el) => {
+    el.addEventListener("mouseenter", () => {
+        const text = el.dataset.tooltip;
+        if (!text) return;
+        tooltip.textContent = text;
+        tooltip.classList.add("visible");
+
+        // Measure after showing so offsetHeight is accurate
+        const rect = el.getBoundingClientRect();
+        const h = tooltip.offsetHeight;
+        const gap = 6;
+        const top = rect.top - h - gap >= 0
+            ? rect.top - h - gap          // above
+            : rect.bottom + gap;           // below (near top of popup)
+
+        tooltip.style.top = `${top}px`;
+        tooltip.style.left = `${(POPUP_W - TOOLTIP_W) / 2}px`; // always centered
+    });
+    el.addEventListener("mouseleave", () => tooltip.classList.remove("visible"));
+});
+
 requestCountReset.addEventListener("click", async () => {
     if (!currentSiteId) return;
     const data = await safeSendMessage<WeeklyRequestCount>({

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_CONFIG: Readonly<ExtensionConfig> = Object.freeze({
     fetchInterceptEnabled: true,
     theme: "dark",
     autoLoad: true,
+    weeklyRequestLimit: 3000,
 });
 
 /** localStorage key used by settings bridge → MAIN-world fetch interceptor. */
@@ -22,6 +23,7 @@ export const REQUEST_COUNTS_KEY = "acsb_request_counts" as const;
 export const CONFIG_LIMITS = Object.freeze({
     visibleMessageLimit: { min: 1, max: 200 },
     loadMoreBatchSize: { min: 1, max: 50 },
+    weeklyRequestLimit: { min: 0, max: 99999 },
 });
 
 export const EXTENSION_NAME = "AI Chat Speed Booster" as const;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -16,6 +16,9 @@ export const DEFAULT_CONFIG: Readonly<ExtensionConfig> = Object.freeze({
 /** localStorage key used by settings bridge → MAIN-world fetch interceptor. */
 export const LOCALSTORAGE_BRIDGE_KEY = "acsb_bridge_config" as const;
 
+/** chrome.storage.local key for per-site weekly request counts. */
+export const REQUEST_COUNTS_KEY = "acsb_request_counts" as const;
+
 export const CONFIG_LIMITS = Object.freeze({
     visibleMessageLimit: { min: 1, max: 200 },
     loadMoreBatchSize: { min: 1, max: 50 },

--- a/src/shared/sites.ts
+++ b/src/shared/sites.ts
@@ -4,6 +4,7 @@ export interface SiteSelectors {
     readonly messageTurn: string;
     readonly scrollContainer: string;
     readonly scrollContainerAlt?: string;
+    readonly userMessageSelector?: string;
 }
 
 export interface StatusAnchors {
@@ -59,6 +60,7 @@ export interface SiteConfig {
     readonly statusAnchors?: StatusAnchors;
     readonly ui?: SiteUI;
     readonly fetchIntercept?: FetchInterceptConfig;
+    readonly weeklyRequestLimit?: number;
 }
 
 export const SITES: readonly SiteConfig[] = sitesConfig as SiteConfig[];

--- a/src/shared/sites.ts
+++ b/src/shared/sites.ts
@@ -60,7 +60,6 @@ export interface SiteConfig {
     readonly statusAnchors?: StatusAnchors;
     readonly ui?: SiteUI;
     readonly fetchIntercept?: FetchInterceptConfig;
-    readonly weeklyRequestLimit?: number;
 }
 
 export const SITES: readonly SiteConfig[] = sitesConfig as SiteConfig[];

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,6 +1,6 @@
 import { storageGet, storageSet, onStorageChanged } from "./browser-api";
-import { STORAGE_KEY, DEFAULT_CONFIG, CONFIG_LIMITS } from "./constants";
-import type { ExtensionConfig } from "./types";
+import { STORAGE_KEY, DEFAULT_CONFIG, CONFIG_LIMITS, REQUEST_COUNTS_KEY } from "./constants";
+import type { ExtensionConfig, WeeklyRequestCount } from "./types";
 import { logger } from "./logger";
 
 function clamp(value: number, min: number, max: number): number {
@@ -55,4 +55,39 @@ export function onConfigChanged(callback: (config: ExtensionConfig) => void): vo
         const newValue = changes[STORAGE_KEY].newValue as Partial<ExtensionConfig> | undefined;
         callback(sanitiseConfig(newValue));
     });
+}
+
+// ---------------------------------------------------------------------------
+// Weekly request counters
+// ---------------------------------------------------------------------------
+
+function getMondayUTCTimestamp(): number {
+    const now = new Date();
+    const dayOfWeek = now.getUTCDay(); // 0=Sun, 1=Mon, …
+    const daysSinceMonday = (dayOfWeek + 6) % 7;
+    return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - daysSinceMonday);
+}
+
+export async function loadRequestCount(siteId: string): Promise<WeeklyRequestCount> {
+    const raw = await storageGet<Record<string, WeeklyRequestCount>>(REQUEST_COUNTS_KEY);
+    const weekStart = getMondayUTCTimestamp();
+    const entry = raw?.[siteId];
+    if (!entry || entry.weekStart !== weekStart) return { count: 0, weekStart };
+    return entry;
+}
+
+export async function incrementRequestCount(siteId: string, amount = 1): Promise<WeeklyRequestCount> {
+    const raw = (await storageGet<Record<string, WeeklyRequestCount>>(REQUEST_COUNTS_KEY)) ?? {};
+    const weekStart = getMondayUTCTimestamp();
+    const existing = raw[siteId];
+    const count = (existing?.weekStart === weekStart ? existing.count : 0) + amount;
+    await storageSet(REQUEST_COUNTS_KEY, { ...raw, [siteId]: { count, weekStart } });
+    return { count, weekStart };
+}
+
+export async function resetRequestCount(siteId: string): Promise<WeeklyRequestCount> {
+    const raw = (await storageGet<Record<string, WeeklyRequestCount>>(REQUEST_COUNTS_KEY)) ?? {};
+    const weekStart = getMondayUTCTimestamp();
+    await storageSet(REQUEST_COUNTS_KEY, { ...raw, [siteId]: { count: 0, weekStart } });
+    return { count: 0, weekStart };
 }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -26,8 +26,9 @@ function sanitiseConfig(raw: Partial<ExtensionConfig> | undefined): ExtensionCon
             ? base.statusPosition
             : DEFAULT_CONFIG.statusPosition,
         fetchInterceptEnabled: typeof base.fetchInterceptEnabled === "boolean" ? base.fetchInterceptEnabled : DEFAULT_CONFIG.fetchInterceptEnabled,
-        autoLoad: typeof base.autoLoad === "boolean" ? base.autoLoad : DEFAULT_CONFIG.autoLoad, // New addition for auto-load validation
-        theme: base.theme === "light" || base.theme === "dark" ? base.theme : DEFAULT_CONFIG.theme, // New addition for theme validation
+        autoLoad: typeof base.autoLoad === "boolean" ? base.autoLoad : DEFAULT_CONFIG.autoLoad,
+        weeklyRequestLimit: clamp(base.weeklyRequestLimit ?? DEFAULT_CONFIG.weeklyRequestLimit, CONFIG_LIMITS.weeklyRequestLimit.min, CONFIG_LIMITS.weeklyRequestLimit.max),
+        theme: base.theme === "light" || base.theme === "dark" ? base.theme : DEFAULT_CONFIG.theme,
     };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,9 @@ export interface ExtensionConfig {
     // UI theme preference.
     readonly theme: Theme;
     // Auto loads 1 extra conversation turn when the user scrolls to the top of the chat.
-    readonly autoLoad: boolean; // New addition for auto-load preference
+    readonly autoLoad: boolean;
+    // Weekly request limit shown in the popup counter. 0 = just count, no limit displayed.
+    readonly weeklyRequestLimit: number;
 }
 
 export interface TrackedMessage {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,7 +35,10 @@ export enum MessageType {
     TOGGLE_ENABLED = "TOGGLE_ENABLED",
     TOGGLE_STATUS = "TOGGLE_STATUS",
     TOGGLE_FETCH_INTERCEPT = "TOGGLE_FETCH_INTERCEPT",
-    TOGGLE_AUTO_LOAD = "TOGGLE_AUTO_LOAD", // New message type for toggling auto-load
+    TOGGLE_AUTO_LOAD = "TOGGLE_AUTO_LOAD",
+    GET_REQUEST_COUNT = "GET_REQUEST_COUNT",
+    INCREMENT_REQUEST_COUNT = "INCREMENT_REQUEST_COUNT",
+    RESET_REQUEST_COUNT = "RESET_REQUEST_COUNT",
 }
 
 export interface ExtensionMessage {
@@ -70,4 +73,10 @@ export interface ExtensionStatus {
     readonly hiddenMessages: number;
     readonly showStatus: boolean;
     readonly statusPosition: StatusPosition;
+    readonly siteId?: string;
+}
+
+export interface WeeklyRequestCount {
+    readonly count: number;
+    readonly weekStart: number;
 }


### PR DESCRIPTION
Closes #19

## What's new

Adds a **Weekly requests** counter to the popup that appears automatically when you're on ChatGPT.

- Tracks messages sent per week, resets every Monday
- Configurable limit (default 3,000 for ChatGPT Plus) — editable directly in the popup
- Set to **0** to just count with no limit shown
- Turns amber at ≥ 80 % of the limit
- Manual reset button if needed

## Also in this PR

- Re-applies the `SetAutoLoad` infinite-loop fix from PR #20 (the fix commit was local-only and didn't make it into the merge)
- Compact popup layout: Fast mode + Auto load share one row, Visible + Batch share one row
- Hover tooltips on every setting card
- Version bump to v1.4.3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)