### PR TITLE
Add extension version label and revert auto-load behavior

### DIFF
--- a/browsers/chrome/manifest.json
+++ b/browsers/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/edge/manifest.json
+++ b/browsers/edge/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/firefox/manifest.json
+++ b/browsers/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/browsers/safari/manifest.json
+++ b/browsers/safari/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "AI Chat Speed Booster",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "Speeds up AI chats by showing recent messages first and letting you load older ones on demand.",
     "permissions": [
         "storage"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ai-chat-speed-booster",
-    "version": "1.4.4",
+    "version": "1.4.5",
     "description": "Browser extension that speeds up AI chat apps (ChatGPT, Claude, etc.) by lazily loading conversation messages with FIFO management",
     "private": true,
     "scripts": {

--- a/src/content/DOMObserver.ts
+++ b/src/content/DOMObserver.ts
@@ -238,7 +238,7 @@ export class DOMObserver {
     }
 
     private static readonly AUTO_LOAD_COOLDOWN_MS = 800;
-
+/*
     private readonly handleScroll = (): void => {
         if (this.scrollRaf) cancelAnimationFrame(this.scrollRaf);
         if (this.visibleMessages >= this.totalMessages) return; // nothing hidden left to reveal
@@ -258,4 +258,53 @@ export class DOMObserver {
             this.callbacks.onScrollToTop();
         });
     };
+*/
+
+	private readonly handleScroll = (): void => {
+		if (this.scrollRaf) cancelAnimationFrame(this.scrollRaf);
+		if (this.visibleMessages >= this.totalMessages) return; // nothing hidden left to reveal
+
+		this.scrollRaf = requestAnimationFrame(() => {
+			const el = this.scrollEl ?? this.findScrollContainer();
+			if (!el) return;
+
+			const max = el.scrollHeight - el.clientHeight;
+			const percentFromTop = max > 0 ? (el.scrollTop / max) * 100 : 100;
+
+			if (percentFromTop > 10) return;
+
+			// I still prefer this approach over the previous cooldown/debounce logic,
+			// since that depended on the previous scroll tick timing and could become
+			// unreliable while the user was actively scrolling near the top.
+			//
+			// In practice, users could end up needing to scroll down and back up again
+			// before auto-load would trigger, because all scroll events inside the
+			// cooldown window were ignored.
+			//
+			// This approach triggers auto-load immediately, then slightly scrolls down
+			// afterward only if the UI itself did not already shift the scroll position,
+			// as in Gemini, preventing repeated auto-load triggers while keeping
+			// scrolling responsive.
+			//
+			// Keeping the old implementation commented for now since it can easily be
+			// restored if needed.
+
+			this.callbacks.onScrollToTop();
+
+			requestAnimationFrame(() => {
+				const updatedMax = el.scrollHeight - el.clientHeight;
+				const updatedPercent =
+					updatedMax > 0 ? (el.scrollTop / updatedMax) * 100 : 100;
+
+				if (updatedPercent <= 10) {
+					el.scrollTo({
+						top: 0.12 * el.scrollHeight,
+						behavior: "smooth"
+					});
+
+					logger.debug("Auto scrolled down slightly to prevent multiple auto-load triggers");
+				}
+			});
+		});
+	};
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -82,6 +82,13 @@ body {
     color: var(--accent);
 }
 
+.popup-header__status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
 .popup-header__status {
     margin-top: 6px;
     font-size: 12px;
@@ -139,7 +146,7 @@ body {
 
 .popup-settings {
     padding: 4px 15px 15px;
-    display: flex;
+    display: none; /* Hidden by default to prevent settings UI flashing on unsupported sites */
     flex-direction: column;
     gap: 8px;
 }
@@ -227,6 +234,7 @@ body {
     outline: none;
     transition: border-color var(--transition);
     -moz-appearance: textfield;
+    appearance: textfield; /* To remove the warning */
 }
 
 .setting__input::-webkit-inner-spin-button,

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -37,7 +37,10 @@
                     <span class="toggle__slider"></span>
                 </label>
             </div>
-            <p class="popup-header__status" id="status-text">Loading…</p>
+                <div class="popup-header__status-row" >
+                    <p class="popup-header__status" id="status-text">Loading…</p>
+                    <p class="popup-header__status" id="version-text"></p>
+                </div>
         </header>
 
         <section class="popup-settings" aria-label="Settings">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -11,6 +11,7 @@ const toggleHideOld = document.getElementById("toggle-hide-old") as HTMLInputEle
 const visibleLimitInput = document.getElementById("visible-limit") as HTMLInputElement;
 const batchSizeInput = document.getElementById("batch-size") as HTMLInputElement;
 const statusText = document.getElementById("status-text") as HTMLElement;
+const versionText = document.getElementById("version-text") as HTMLElement;
 const settingsSection = document.querySelector(".popup-settings") as HTMLElement;
 const positionPicker = document.getElementById("position-picker") as HTMLElement;
 const positionButtons = positionPicker.querySelectorAll<HTMLButtonElement>(".position-picker__btn");
@@ -51,6 +52,9 @@ async function safeSendMessage<T>(message: unknown): Promise<T | null> {
 }
 
 async function init(): Promise<void> {
+    const manifest = chrome.runtime.getManifest();
+    versionText.textContent = `(v${manifest.version})`; // New: set the version text from manifest
+
     const config = await safeSendMessage<ExtensionConfig>({ type: MessageType.GET_CONFIG });
     const finalConfig = config ?? DEFAULT_CONFIG;
     applyTheme(finalConfig.theme);
@@ -81,7 +85,7 @@ async function refreshStatus(): Promise<void> {
             statusText.textContent =
                 `${Math.floor(status.visibleMessages / 2)}/${Math.floor(status.totalMessages / 2)} messages visible` +
                 (status.hiddenMessages > 0 ? ` · ${Math.floor(status.hiddenMessages / 2)} hidden` : "");
-            settingsSection.style.display = "";
+            settingsSection.style.display = "flex"; // Set to flex only when the site is actually supported
             currentSiteId = status.siteId;
             await refreshRequestCounter();
         } else {


### PR DESCRIPTION
## Summary
This PR adds a visible extension version label to the popup UI and includes a few related fixes/improvements:

- Reverted auto-load logic to the previous non-cooldown behavior.
- Fixed popup settings briefly flashing before status initialization completed.
- Added dynamic version text sourced directly from the extension manifest.

## What Changed
- Added version label to the popup header/status area. (#27)
- Dynamically fetches extension version using `chrome.runtime.getManifest()`.
- Fixed popup UI flash by hiding settings until status initialization completes.
- Reverted top-scroll auto-load logic to the previous implementation to avoid missed triggers caused by cooldown timing. (#26)

## Tested
> Tested on Chrome / Brave

- Verified version updates automatically from manifest.
- Verified popup no longer flashes settings before initialization.
- Verified auto-load triggers consistently while scrolling near the top.
- Verified repeated auto-load triggers are prevented correctly.

## Notes
- Bumped extension version to `1.4.5`
- Version label updates automatically with future releases.
- Previous cooldown-based auto-load implementation has been preserved in comments for easier comparison/reverting if needed.

## Screenshot
<img width="314" height="427" alt="Screenshot 2026-05-17 192539" src="https://github.com/user-attachments/assets/3e2fe151-e2a1-4fd1-80cc-1fb29c63314c" />

Closes #27, Fixes #26